### PR TITLE
Line graph + style changes

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -599,6 +599,7 @@ div.container-fluid {
 .modal-footer {
   padding: 20px 0;
   margin-bottom: -40px;
+  border-top: none;
 }
 .modal-footer > * {
   margin: 0;
@@ -612,6 +613,9 @@ div.container-fluid {
 /* definitions modal */
 dt {
   font-weight: 600;
+}
+dd {
+  padding-bottom: 10px;
 }
 
 /* buttons */

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -520,6 +520,19 @@ div.container-fluid {
 	color: #1e1e1e;
 }
 
+
+/* card columns */
+.col-md-4 {
+  min-width: 425px;
+}
+.row {
+  justify-content: center;
+}
+.pb-1, .py-1 {
+  padding-bottom:30px;
+}
+
+
 /* modal windows */
 .modal-dialog {
   outline: 0;

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -93,7 +93,6 @@ html {
 }
 
 /* Global Page Elements */
-
 body {
   color: #414141;
   font-family: 'Lora', Georgia, Times New Roman, serif;
@@ -163,13 +162,13 @@ a:hover {
   text-decoration: none;
 }
 
+
 /* Child Theme Ribbon */
-
-header h1 {
+/* header h1 {
   margin-bottom: 0;
-}
+} */
 
-h1 #content, h1 #content:hover, h1 #content:focus {
+/* h1 #content, h1 #content:hover, h1 #content:focus {
   font-family: 'Trueno', Arial, Helvetica, sans-serif;
   font-size: 24px;
   line-height: 1.3;
@@ -181,63 +180,29 @@ h1 #content, h1 #content:hover, h1 #content:focus {
   padding: 10px 25px;
   background: linear-gradient(-46deg,#0579b8 0%,#2a5280 100%);
   text-decoration:none;
-}
+} */
 
-span.title-verify {
+/* span.title-verify {
   font-family: 'Lora', Georgia, Times New Roman, serif;
   font-style: italic;
-}
+} */
 
-.logo-background {
+/* .logo-background {
   background-color: #1e1e1e;
   text-align: center;
-}
+} */
 
-.logo-background img {
+/* .logo-background img {
   margin: 19px auto;
-}
+} */
 
-.header-padding{
+/* .header-padding{
   margin-right: 0px;
   margin-left: 0px;
-}
+} */
 
-/* User Account */
-
-#user-account {
-  font-family: 'Trueno', Arial, Helvetica, sans-serif;
-  font-size: 14px;
-  display: inline-block;
-  padding: 15px 0;
-}
-
-#user-account a {
-  border-bottom: 3px solid transparent;
-  color: #1e1e1e;
-  -webkit-transition: border 0.28s cubic-bezier(0.28,1.08,1,0.96);
-  transition: border 0.28s cubic-bezier(0.28,1.08,1,0.96);
-}
-
-#user-account a:hover {
-  border-bottom: 3px solid rgba(30,30,30,0.3);
-  text-decoration: none;
-}
-
-#user-account .row.justify-content-end {
-  margin-right: 0;
-}
-
-#user-name {
-  text-align: right;
-}
-
-#logout {
-  font-weight: bold;
-  border-left: 1px solid #C0C0C0;
-}
 
 /* Form Elements */
-
 form label {
   font-family: 'Trueno', Arial, Helvetica, sans-serif;
   font-size: 1.3em;
@@ -339,8 +304,8 @@ form input[type="submit"]:hover {
   font-size: 16px;
 }
 
-/* Results block */
 
+/* Results block */
 #result-message p {
   font-family: 'Trueno', Arial, Helvetica, sans-serif;
   font-size: 1.3em;
@@ -444,6 +409,8 @@ input[type=number] {
 
 
 
+
+
 /* Maura's styles */
 
 /* header */
@@ -461,6 +428,7 @@ input[type=number] {
   background-image: linear-gradient(-46deg, #0579b8 0%, #2a5280 100%);
   color: white;
   flex: auto;
+  font-family: 'Lora', Georgia, Times New Roman, serif;
   font-size: 20px;
   font-style: italic;
   font-weight: 400;
@@ -522,12 +490,34 @@ input[type=number] {
   max-width: 100%;
 }
 
+
 /* dashboard size */
 .container {
-  max-width: 1450px;
+  /* max-width: 1450px; */
+  max-width: 1800px;
 }
 div.container-fluid {
+  padding-top: 30px;
   padding-bottom: 80px;
+}
+
+/* texty text */
+.col {
+	max-width: 930px;
+	margin-left: auto;
+	margin-right: auto;
+	text-align: center;
+}
+/* time stamp */
+.hl__time-stamp {
+	font-family: "Trueno", sans-serif;
+	font-weight: 700;
+	font-size: 20px;
+	line-height: 30px;
+	margin-bottom: 20px;
+	text-transform: uppercase;
+	letter-spacing: 1.5px;
+	color: #1e1e1e;
 }
 
 /* modal windows */
@@ -548,12 +538,10 @@ div.container-fluid {
     width: 90%;
   }
 }
-
 .modal-content {
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
   padding: 40px;
 }
-
 .modal-header {
   border-bottom: 0;
   padding: 0;
@@ -589,13 +577,12 @@ div.container-fluid {
 .modal-header button.close:hover, .modal-header button.close:focus {
   background: #eb001b;
 }
-
 .modal-body {
   padding: 0;
-  font-family: Lora, Georgia, serif;
+  font-family: "Trueno", sans-serif;
   font-size: 15px;
+  font-weight: 300;
 }
-
 .modal-footer {
   padding: 20px 0;
   margin-bottom: -40px;
@@ -604,11 +591,15 @@ div.container-fluid {
   margin: 0;
 }
 
+
 /* status diagram modal */
 #diagram .modal-body {
 	text-align: center;
 }
-
+/* definitions modal */
+dt {
+  font-weight: 600;
+}
 
 /* buttons */
 .btn {
@@ -647,7 +638,7 @@ div.container-fluid {
 }
 
 
-/* tabs */
+/* tabs + card styles */
 .nav-link {
   font-family: 'Trueno', Arial, Helvetica, sans-serif;
   font-size: 12px;
@@ -667,7 +658,9 @@ div.container-fluid {
   width:100%;
   margin-bottom:1rem;
   color:#414141;
-  font-size: 17px;
+  font-family: "Trueno", sans-serif;
+  font-size: 15px;
+  font-weight: 300;
 }
 .tab-pane p {
   font-family: 'Trueno', Arial, Helvetica, sans-serif;
@@ -680,4 +673,13 @@ div.container-fluid {
 }
 th {
   font-weight: normal;
+}
+td:last-child {
+  text-align: right;
+}
+
+.card-body a {
+  font-size: 15px;
+  font-weight: normal;
+  line-height: 24px;
 }

--- a/app/static/js/piechart.js
+++ b/app/static/js/piechart.js
@@ -5,12 +5,12 @@ $(document).ready(function () {
   Chart.defaults.font.family = 'Trueno';
   Chart.defaults.font.size = 14;
   // Chart.defaults.font.style = 'normal';
-  // Chart.defaults.font.weight = 600;
+  Chart.defaults.font.weight = 300;
   Chart.defaults.font.lineHeight = 1.733;
 
   // Chart.defaults.plugins.title.font.color = #000;
   Chart.defaults.plugins.title.font.size = 20;
-  Chart.defaults.plugins.title.font.weight = 600;
+  Chart.defaults.plugins.title.font.weight = 700;
   Chart.defaults.plugins.title.font.lineHeight = 1.5;
 
   // chart colors

--- a/app/static/js/piechart.js
+++ b/app/static/js/piechart.js
@@ -14,7 +14,7 @@ $(document).ready(function () {
   Chart.defaults.plugins.title.font.lineHeight = 1.5;
 
   // chart colors
-  let colors = ['#c0c0c0','#f8c21c','#a51c30','#eb001b','#414141','#0579b8','#3e6f7d','green','red'];
+  let colors = ['#c0c0c0','#f8c21c','#a51c30','#eb001b','#414141','#0579b8','#8BDA4C','#3E6F7D','red'];
   let lineColor = '#3e6f7d';
 
   // labels
@@ -35,53 +35,49 @@ $(document).ready(function () {
       $(".hl__time").html(time);
 
       let bytes_data = [
-        data[i]["gsx$bybytes"]["$t"],
-        data[i]["gsx$_cre1l"]["$t"],
-        data[i]["gsx$_chk2m"]["$t"],
-        data[i]["gsx$_ciyn3"]["$t"],
-        data[i]["gsx$_ckd7g"]["$t"],
-        data[i]["gsx$_clrrx"]["$t"],
-        data[i]["gsx$_cyevm"]["$t"],
-        data[i]["gsx$_cztg3"]["$t"],
-        data[i]["gsx$_d180g"]["$t"]
+        data[i]["gsx$bybytes"]["$t"], //pending
+        data[i]["gsx$_cre1l"]["$t"],  // in process
+        data[i]["gsx$_chk2m"]["$t"],  // failure
+        data[i]["gsx$_ciyn3"]["$t"],  // unrecoverable
+        data[i]["gsx$_ckd7g"]["$t"],  // sensitive
+        data[i]["gsx$_clrrx"]["$t"],  // on hold
+        data[i]["gsx$_cyevm"]["$t"],  // success
+        data[i]["gsx$_cztg3"]["$t"],  // verified
+        data[i]["gsx$_d180g"]["$t"]   // verfied failed
       ];
 
-      let bytes_total = data[i]["gsx$_d2mkx"]["$t"];
-      let bytes_percent_complete = data[i]["gsx$_cssly"]["$t"];
+      let bytes_total = data[i]["gsx$_d2mkx"]["$t"]; // total
+      let bytes_percent_complete = data[i]["gsx$_cssly"]["$t"]; // % complete
 
       let files_data = [
-        data[i]["gsx$byfiles"]["$t"],
-        data[i]["gsx$_cvlqs"]["$t"],
-        data[i]["gsx$_cx0b9"]["$t"],
-        data[i]["gsx$_d9ney"]["$t"],
-        data[i]["gsx$_db1zf"]["$t"],
-        data[i]["gsx$_dcgjs"]["$t"],
-        data[i]["gsx$_ddv49"]["$t"],
-        data[i]["gsx$_d415a"]["$t"],
-        data[i]["gsx$_d5fpr"]["$t"]
+        data[i]["gsx$byfiles"]["$t"], //pending
+        data[i]["gsx$_cvlqs"]["$t"],  // in process
+        data[i]["gsx$_cx0b9"]["$t"],  // failure
+        data[i]["gsx$_d9ney"]["$t"],  // unrecoverable
+        data[i]["gsx$_db1zf"]["$t"],  // sensitive
+        data[i]["gsx$_dcgjs"]["$t"],  // on hold
+        data[i]["gsx$_ddv49"]["$t"],  // success
+        data[i]["gsx$_d415a"]["$t"],  // verified
+        data[i]["gsx$_d5fpr"]["$t"]   // verfied failed
       ];
 
-      let files_total = data[i]["gsx$_d6ua4"]["$t"];
-      let files_percent_complete = data[i]["gsx$_d88ul"]["$t"];
+      let files_total = data[i]["gsx$_d6ua4"]["$t"]; // total
+      let files_percent_complete = data[i]["gsx$_d88ul"]["$t"]; // % complete
 
       let objects_data = [
-        data[i]["gsx$byobjects"]["$t"],
-        data[i]["gsx$_dmair"]["$t"],
-        data[i]["gsx$_dnp34"]["$t"],
-        data[i]["gsx$_dp3nl"]["$t"],
-        data[i]["gsx$_df9om"]["$t"],
-        data[i]["gsx$_dgo93"]["$t"],
-        data[i]["gsx$_di2tg"]["$t"],
-        data[i]["gsx$_djhdx"]["$t"],
-        data[i]["gsx$_dw4je"]["$t"]
+        data[i]["gsx$byobjects"]["$t"], //pending
+        data[i]["gsx$_dmair"]["$t"],    // in process
+        data[i]["gsx$_dnp34"]["$t"],    // failure
+        data[i]["gsx$_dp3nl"]["$t"],    // unrecoverable
+        data[i]["gsx$_df9om"]["$t"],    // sensitive
+        data[i]["gsx$_dgo93"]["$t"],    // on hold
+        data[i]["gsx$_di2tg"]["$t"],    // success
+        data[i]["gsx$_djhdx"]["$t"],    // verified
+        data[i]["gsx$_dw4je"]["$t"]     // verfied failed
       ];
 
-      let objects_total = data[i]["gsx$_dxj3v"]["$t"];
-      let objects_percent_complete = data[i]["gsx$_dyxo8"]["$t"];
-
-      console.log(bytes_data);
-      console.log(files_data);
-      console.log(objects_data);
+      let objects_total = data[i]["gsx$_dxj3v"]["$t"]; // total
+      let objects_percent_complete = data[i]["gsx$_dyxo8"]["$t"]; // % complete
 
       // bytes chart
       let bytesChartOptions = {
@@ -207,6 +203,226 @@ $(document).ready(function () {
       createTable("#bytes-numbers", bytes_data, bytes_total, bytes_percent_complete);
       createTable("#files-numbers", files_data, files_total, files_percent_complete);
       createTable("#objects-numbers", objects_data, objects_total, objects_percent_complete);
+
+
+      // create arrays for trends graphs
+      let dateArray = [];
+
+      // let bytesArray = [[],[],[],[],[],[],[],[],[]];
+
+      let bytesRemaining = [];
+      let filesRemaining = [];
+      let objectsRemaining = [];
+
+      for(i=1;i<data.length;i++){
+        dateArray.push(data[i]["gsx$date"]["$t"]); // array of dates for x-axis
+
+        // let bytesArrayTrend = [
+        //   data[i]["gsx$bybytes"]["$t"],
+        //   data[i]["gsx$_cre1l"]["$t"],
+        //   data[i]["gsx$_chk2m"]["$t"],
+        //   data[i]["gsx$_ciyn3"]["$t"],
+        //   data[i]["gsx$_ckd7g"]["$t"],
+        //   data[i]["gsx$_clrrx"]["$t"],
+        //   data[i]["gsx$_cyevm"]["$t"],
+        //   data[i]["gsx$_cztg3"]["$t"],
+        //   data[i]["gsx$_d180g"]["$t"]
+        // ];
+
+        // for(j=0;j<bytesArrayTrend.length;j++){
+        //   bytesArray[j].push((bytesArrayTrend[j])/(10**9));
+        // }
+
+
+        // let filesRemaining = parseInt(data[i]["gsx$_d6ua4"]["$t"]) - (parseInt(data[i]["gsx$_di2tg"]["$t"]) + parseInt(data[i]["gsx$_djhdx"]["$t"]) + parseInt(data[i]["gsx$_dw4je"]["$t"]));
+        //
+        // filesRemainingArray.push(filesRemaining/(10**6));
+
+        function calcRemaining(array, total, success, verified, verified_failed, exponent){
+          let remaining = parseInt(total) - (parseInt(success) + parseInt(verified) + parseInt(verified_failed));
+          array.push(remaining/(10**exponent));
+        }
+
+        calcRemaining(bytesRemaining, data[i]["gsx$_d2mkx"]["$t"], data[i]["gsx$_cyevm"]["$t"], data[i]["gsx$_cztg3"]["$t"], data[i]["gsx$_d180g"]["$t"], 12);
+
+        calcRemaining(filesRemaining, data[i]["gsx$_d6ua4"]["$t"], data[i]["gsx$_ddv49"]["$t"], data[i]["gsx$_d415a"]["$t"], data[i]["gsx$_d5fpr"]["$t"], 6);
+
+        calcRemaining(objectsRemaining, data[i]["gsx$_dxj3v"]["$t"], data[i]["gsx$_di2tg"]["$t"], data[i]["gsx$_djhdx"]["$t"], data[i]["gsx$_dw4je"]["$t"], 3);
+      }
+
+      // bytes trends
+      let bytesTrendsOptions = {
+        plugins: {
+          tooltip: {
+            mode: 'index',
+            intersect: false
+          },
+          title: {
+            display: true,
+            text: "Progress by bytes",
+            padding:{
+              top:10,
+              bottom:10
+            }
+          }
+        },
+        scales: {
+          x: {
+            title: {
+              display: false,
+              text: 'Date'
+            }
+          },
+          y: {
+            title: {
+              display: true,
+              text: 'TB remaining'
+            }
+          }
+        }
+      };
+      let bytesTrendsData = {
+        labels: dateArray,
+        datasets: [{
+            label: 'Total TB remaining',
+            data: bytesRemaining,
+            borderColor: colors[2],
+            backgroundColor: colors[2],
+            tension: 0.1
+        }]
+      };
+      let bytesTrends = document.getElementById("bytesTrends");
+      if (bytesTrends) {
+        new Chart(bytesTrends, {
+          type: 'line',
+          data: bytesTrendsData,
+          options: bytesTrendsOptions
+        });
+      }
+      let bytesTrendsModal = document.getElementById("bytesTrendsModal");
+      if (bytesTrendsModal) {
+        new Chart(bytesTrendsModal, {
+          type: 'line',
+          data: bytesTrendsData,
+          options: bytesTrendsOptions
+        });
+      }
+
+      // files trends
+      let filesTrendsOptions = {
+        plugins: {
+          tooltip: {
+            mode: 'index',
+            intersect: false
+          },
+          title: {
+            display: true,
+            text: "Progress by files",
+            padding:{
+              top:10,
+              bottom:10
+            }
+          }
+        },
+        scales: {
+          x: {
+            title: {
+              display: false,
+              text: 'Date'
+            }
+          },
+          y: {
+            title: {
+              display: true,
+              text: 'MB remaining'
+            }
+          }
+        }
+      };
+      let filesTrendsData = {
+        labels: dateArray,
+        datasets: [{
+            label: 'Total MB remaining',
+            data: filesRemaining,
+            borderColor: colors[2],
+            backgroundColor: colors[2],
+            tension: 0.1
+        }]
+      };
+      let filesTrends = document.getElementById("filesTrends");
+      if (filesTrends) {
+        new Chart(filesTrends, {
+          type: 'line',
+          data: filesTrendsData,
+          options: filesTrendsOptions
+        });
+      }
+      let filesTrendsModal = document.getElementById("filesTrendsModal");
+      if (filesTrendsModal) {
+        new Chart(filesTrendsModal, {
+          type: 'line',
+          data: filesTrendsData,
+          options: filesTrendsOptions
+        });
+      }
+
+      // objects trends
+      let objectsTrendsOptions = {
+        plugins: {
+          tooltip: {
+            mode: 'index',
+            intersect: false
+          },
+          title: {
+            display: true,
+            text: "Progress by objects",
+            padding:{
+              top:10,
+              bottom:10
+            }
+          }
+        },
+        scales: {
+          x: {
+            title: {
+              display: false,
+              text: 'Date'
+            }
+          },
+          y: {
+            title: {
+              display: true,
+              text: 'KB Remaining'
+            }
+          }
+        }
+      };
+      let objectsTrendsData = {
+        labels: dateArray,
+        datasets: [{
+            label: 'Total KB remaining',
+            data: objectsRemaining,
+            borderColor: colors[2],
+            backgroundColor: colors[2],
+            tension: 0.1
+        }]
+      };
+      let objectsTrends = document.getElementById("objectsTrends");
+      if (objectsTrends) {
+        new Chart(objectsTrends, {
+          type: 'line',
+          data: objectsTrendsData,
+          options: objectsTrendsOptions
+        });
+      }
+      let objectsTrendsModal = document.getElementById("objectsTrendsModal");
+      if (objectsTrendsModal) {
+        new Chart(objectsTrendsModal, {
+          type: 'line',
+          data: objectsTrendsData,
+          options: objectsTrendsOptions
+        });
+      }
     }
   };
 
@@ -235,5 +451,11 @@ $(document).ready(function () {
   // add commas to numbers in table view
   function numberWithCommas(x) {
     return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  }
+
+  // create arrays for line graph
+  function createArray(arrayName){
+    let pendingArray = [];
+
   }
 });

--- a/app/static/js/piechart.js
+++ b/app/static/js/piechart.js
@@ -10,7 +10,7 @@ $(document).ready(function () {
 
   // Chart.defaults.plugins.title.font.color = #000;
   Chart.defaults.plugins.title.font.size = 20;
-  Chart.defaults.plugins.title.font.weight = 700;
+  Chart.defaults.plugins.title.font.weight = 600;
   Chart.defaults.plugins.title.font.lineHeight = 1.5;
 
   // chart colors
@@ -207,41 +207,12 @@ $(document).ready(function () {
 
       // create arrays for trends graphs
       let dateArray = [];
-
-      // let bytesArray = [[],[],[],[],[],[],[],[],[]];
-
       let bytesRemaining = [];
       let filesRemaining = [];
       let objectsRemaining = [];
 
       for(i=1;i<data.length;i++){
         dateArray.push(data[i]["gsx$date"]["$t"]); // array of dates for x-axis
-
-        // let bytesArrayTrend = [
-        //   data[i]["gsx$bybytes"]["$t"],
-        //   data[i]["gsx$_cre1l"]["$t"],
-        //   data[i]["gsx$_chk2m"]["$t"],
-        //   data[i]["gsx$_ciyn3"]["$t"],
-        //   data[i]["gsx$_ckd7g"]["$t"],
-        //   data[i]["gsx$_clrrx"]["$t"],
-        //   data[i]["gsx$_cyevm"]["$t"],
-        //   data[i]["gsx$_cztg3"]["$t"],
-        //   data[i]["gsx$_d180g"]["$t"]
-        // ];
-
-        // for(j=0;j<bytesArrayTrend.length;j++){
-        //   bytesArray[j].push((bytesArrayTrend[j])/(10**9));
-        // }
-
-
-        // let filesRemaining = parseInt(data[i]["gsx$_d6ua4"]["$t"]) - (parseInt(data[i]["gsx$_di2tg"]["$t"]) + parseInt(data[i]["gsx$_djhdx"]["$t"]) + parseInt(data[i]["gsx$_dw4je"]["$t"]));
-        //
-        // filesRemainingArray.push(filesRemaining/(10**6));
-
-        function calcRemaining(array, total, success, verified, verified_failed, exponent){
-          let remaining = parseInt(total) - (parseInt(success) + parseInt(verified) + parseInt(verified_failed));
-          array.push(remaining/(10**exponent));
-        }
 
         calcRemaining(bytesRemaining, data[i]["gsx$_d2mkx"]["$t"], data[i]["gsx$_cyevm"]["$t"], data[i]["gsx$_cztg3"]["$t"], data[i]["gsx$_d180g"]["$t"], 12);
 
@@ -453,9 +424,9 @@ $(document).ready(function () {
     return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   }
 
-  // create arrays for line graph
-  function createArray(arrayName){
-    let pendingArray = [];
-
+  // create array of total amount remaining
+  function calcRemaining(array, total, success, verified, verified_failed, exponent){
+    let remaining = parseInt(total) - (parseInt(success) + parseInt(verified) + parseInt(verified_failed));
+    array.push(remaining/(10**exponent));
   }
 });

--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -2,10 +2,9 @@
   <div>
     <a href="#content" accesskey="S" onclick="$('#content').focus();" class="sr-only sr-only-focusable">Skip to Main Content</a>
   </div>
-  <div class="hl__header-child__title ">
-    <div href="/" title="Digital Reserves System Migration Dashboard"><span>DRS</span> Migration</div>
-    <!-- <a href="/" title="Digital Reserves System Migration Dashboard"><span>DRS</span> Migration</a> -->
-  </div>
+  <h1 class="hl__header-child__title ">
+    <div href="/" title="Digital Reserves System Migration Dashboard"><span>DRS</span> Migration Dashboard</div>
+  </h1>
   <div class="hl__header-child__logo">
     <section class="hl__linked-image">
       <a href="https://library.harvard.edu/" title="Harvard Library">

--- a/app/templates/piechart.html
+++ b/app/templates/piechart.html
@@ -18,25 +18,25 @@
       <div class="card h-100">
         <ul class="nav nav-tabs" id="bytesTabs" role="tablist">
           <li class="nav-item" role="presentation">
-            <button class="nav-link" id="bytes-chart-tab" data-toggle="tab" data-target="#bytes-chart" type="button" role="tab" aria-controls="bytes-chart" aria-selected="true">Chart</button>
+            <button class="nav-link active" id="bytes-chart-tab" data-toggle="tab" data-target="#bytes-chart" type="button" role="tab" aria-controls="bytes-chart" aria-selected="true">Chart</button>
           </li>
           <li class="nav-item" role="presentation">
             <button class="nav-link" id="bytes-numbers-tab" data-toggle="tab" data-target="#bytes-numbers" type="button" role="tab" aria-controls="bytes-numbers" aria-selected="false">Numbers</button>
           </li>
           <li class="nav-item" role="presentation">
-            <button class="nav-link active" id="bytes-trends-tab" data-toggle="tab" data-target="#bytes-trends" type="button" role="tab" aria-controls="bytes-trends" aria-selected="false">Trends</button>
+            <button class="nav-link" id="bytes-trends-tab" data-toggle="tab" data-target="#bytes-trends" type="button" role="tab" aria-controls="bytes-trends" aria-selected="false">Trends</button>
           </li>
         </ul>
         <div class="card-body">
           <div class="tab-content" id="myTabContent">
-            <div class="tab-pane fade" id="bytes-chart" role="tabpanel" aria-labelledby="bytes-chart-tab">
+            <div class="tab-pane fade show active" id="bytes-chart" role="tabpanel" aria-labelledby="bytes-chart-tab">
               <canvas id="bytesChart"></canvas>
             </div>
             <div class="tab-pane fade" id="bytes-numbers" role="tabpanel" aria-labelledby="bytes-numbers-tab">
               <p>Progress by bytes</p>
               <table class="table table-sm"><tbody></tbody></table>
             </div>
-            <div class="tab-pane fade show active" id="bytes-trends" role="tabpanel" aria-labelledby="bytes-trends-tab">
+            <div class="tab-pane fade" id="bytes-trends" role="tabpanel" aria-labelledby="bytes-trends-tab">
               <canvas id="bytesTrends"></canvas>
               <a href="#" data-toggle="modal" data-target="#bytesModal">Click to enlarge<span class="sr-only">progress by bytes line graph</span></a>
             </div>
@@ -50,25 +50,25 @@
       <div class="card h-100">
         <ul class="nav nav-tabs" id="filesTabs" role="tablist">
           <li class="nav-item" role="presentation">
-            <button class="nav-link" id="files-chart-tab" data-toggle="tab" data-target="#files-chart" type="button" role="tab" aria-controls="files-chart" aria-selected="true">Chart</button>
+            <button class="nav-link active" id="files-chart-tab" data-toggle="tab" data-target="#files-chart" type="button" role="tab" aria-controls="files-chart" aria-selected="true">Chart</button>
           </li>
           <li class="nav-item" role="presentation">
             <button class="nav-link" id="files-numbers-tab" data-toggle="tab" data-target="#files-numbers" type="button" role="tab" aria-controls="files-numbers" aria-selected="false">Numbers</button>
           </li>
           <li class="nav-item" role="presentation">
-            <button class="nav-link active" id="files-trends-tab" data-toggle="tab" data-target="#files-trends" type="button" role="tab" aria-controls="files-trends" aria-selected="false">Trends</button>
+            <button class="nav-link" id="files-trends-tab" data-toggle="tab" data-target="#files-trends" type="button" role="tab" aria-controls="files-trends" aria-selected="false">Trends</button>
           </li>
         </ul>
         <div class="card-body">
           <div class="tab-content" id="myTabContent">
-            <div class="tab-pane fade" id="files-chart" role="tabpanel" aria-labelledby="files-chart-tab">
+            <div class="tab-pane fade show active" id="files-chart" role="tabpanel" aria-labelledby="files-chart-tab">
               <canvas id="filesChart"></canvas>
             </div>
             <div class="tab-pane fade" id="files-numbers" role="tabpanel" aria-labelledby="files-numbers-tab">
               <p>Progress by files</p>
               <table class="table table-sm"><tbody></tbody></table>
             </div>
-            <div class="tab-pane fade show active" id="files-trends" role="tabpanel" aria-labelledby="files-trends-tab">
+            <div class="tab-pane fade" id="files-trends" role="tabpanel" aria-labelledby="files-trends-tab">
               <canvas id="filesTrends"></canvas>
               <a href="#" data-toggle="modal" data-target="#filesModal">Click to enlarge<span class="sr-only">progress by files line graph</span></a>
             </div>
@@ -82,25 +82,25 @@
       <div class="card h-100">
         <ul class="nav nav-tabs" id="objectsTabs" role="tablist">
           <li class="nav-item" role="presentation">
-            <button class="nav-link" id="objects-chart-tab" data-toggle="tab" data-target="#objects-chart" type="button" role="tab" aria-controls="objects-chart" aria-selected="true">Chart</button>
+            <button class="nav-link active" id="objects-chart-tab" data-toggle="tab" data-target="#objects-chart" type="button" role="tab" aria-controls="objects-chart" aria-selected="true">Chart</button>
           </li>
           <li class="nav-item" role="presentation">
             <button class="nav-link" id="objects-numbers-tab" data-toggle="tab" data-target="#objects-numbers" type="button" role="tab" aria-controls="objects-numbers" aria-selected="false">Numbers</button>
           </li>
           <li class="nav-item" role="presentation">
-            <button class="nav-link active" id="objects-trends-tab" data-toggle="tab" data-target="#objects-trends" type="button" role="tab" aria-controls="objects-trends" aria-selected="false">Trends</button>
+            <button class="nav-link" id="objects-trends-tab" data-toggle="tab" data-target="#objects-trends" type="button" role="tab" aria-controls="objects-trends" aria-selected="false">Trends</button>
           </li>
         </ul>
         <div class="card-body">
           <div class="tab-content" id="myTabContent">
-            <div class="tab-pane fade" id="objects-chart" role="tabpanel" aria-labelledby="objects-chart-tab">
+            <div class="tab-pane fade show active" id="objects-chart" role="tabpanel" aria-labelledby="objects-chart-tab">
               <canvas id="objectsChart"></canvas>
             </div>
             <div class="tab-pane fade" id="objects-numbers" role="tabpanel" aria-labelledby="objects-numbers-tab">
               <p>Progress by objects</p>
               <table class="table table-sm"><tbody></tbody></table>
             </div>
-            <div class="tab-pane fade show active" id="objects-trends" role="tabpanel" aria-labelledby="objects-trends-tab">
+            <div class="tab-pane fade" id="objects-trends" role="tabpanel" aria-labelledby="objects-trends-tab">
               <canvas id="objectsTrends"></canvas>
               <a href="#" data-toggle="modal" data-target="#objectsModal">Click to enlarge<span class="sr-only">progress by objects line graph</span></a>
             </div>

--- a/app/templates/piechart.html
+++ b/app/templates/piechart.html
@@ -6,12 +6,11 @@
 <div class="container">
   <div class="row my-3">
     <div class="col">
-      <h1>DRS Migration Dashboard</h1>
-      <p>Welcome to the DRS Data Migration Status Dashboard. Statistics are updated hourly. For an explanation of each status, check the <a href="#" data-toggle="modal" data-target="#definitions">status definitions</a>. Also, refer to the <a href="#" data-toggle="modal" data-target="#diagram">status diagram</a> for a visual representation of the migration workflow.</p>
+      <!-- <h1>DRS Migration Dashboard</h1> -->
+      <p class="hl__time-stamp">Last update: <span class="hl__date">07/13/2021</span>, <span class="hl__time">1:03 PM</span></p>
+      <p>Statistics are updated hourly. For an explanation of each status, check the <a href="#" data-toggle="modal" data-target="#definitions">status definitions</a>. Also, refer to the <a href="#" data-toggle="modal" data-target="#diagram">status diagram</a> for a visual representation of the migration workflow.</p>
     </div>
   </div>
-
-  <p class="hl__time-stamp">Last update: <span class="hl__date">07/13/2021</span>, <span class="hl__time">1:03 PM</span></p>
 
   <div class="row py-2">
     <!-- PROGRESS BY BYTES -->
@@ -19,27 +18,27 @@
       <div class="card h-100">
         <ul class="nav nav-tabs" id="bytesTabs" role="tablist">
           <li class="nav-item" role="presentation">
-            <button class="nav-link active" id="bytes-chart-tab" data-toggle="tab" data-target="#bytes-chart" type="button" role="tab" aria-controls="bytes-chart" aria-selected="true">Chart</button>
+            <button class="nav-link" id="bytes-chart-tab" data-toggle="tab" data-target="#bytes-chart" type="button" role="tab" aria-controls="bytes-chart" aria-selected="true">Chart</button>
           </li>
           <li class="nav-item" role="presentation">
             <button class="nav-link" id="bytes-numbers-tab" data-toggle="tab" data-target="#bytes-numbers" type="button" role="tab" aria-controls="bytes-numbers" aria-selected="false">Numbers</button>
           </li>
           <li class="nav-item" role="presentation">
-            <button class="nav-link" id="bytes-trends-tab" data-toggle="tab" data-target="#bytes-trends" type="button" role="tab" aria-controls="bytes-trends" aria-selected="false">Trends</button>
+            <button class="nav-link active" id="bytes-trends-tab" data-toggle="tab" data-target="#bytes-trends" type="button" role="tab" aria-controls="bytes-trends" aria-selected="false">Trends</button>
           </li>
         </ul>
         <div class="card-body">
           <div class="tab-content" id="myTabContent">
-            <div class="tab-pane fade show active" id="bytes-chart" role="tabpanel" aria-labelledby="bytes-chart-tab">
+            <div class="tab-pane fade" id="bytes-chart" role="tabpanel" aria-labelledby="bytes-chart-tab">
               <canvas id="bytesChart"></canvas>
             </div>
             <div class="tab-pane fade" id="bytes-numbers" role="tabpanel" aria-labelledby="bytes-numbers-tab">
               <p>Progress by bytes</p>
               <table class="table table-sm"><tbody></tbody></table>
             </div>
-            <div class="tab-pane fade" id="bytes-trends" role="tabpanel" aria-labelledby="bytes-trends-tab">
-              Insert line graph
+            <div class="tab-pane fade show active" id="bytes-trends" role="tabpanel" aria-labelledby="bytes-trends-tab">
               <canvas id="bytesTrends"></canvas>
+              <a href="#" data-toggle="modal" data-target="#bytesModal">Click to enlarge<span class="sr-only">progress by bytes line graph</span></a>
             </div>
           </div>
         </div>
@@ -50,28 +49,28 @@
     <div class="col-md-4 py-1">
       <div class="card h-100">
         <ul class="nav nav-tabs" id="filesTabs" role="tablist">
-          <li class="nav-item active" role="presentation">
+          <li class="nav-item" role="presentation">
             <button class="nav-link" id="files-chart-tab" data-toggle="tab" data-target="#files-chart" type="button" role="tab" aria-controls="files-chart" aria-selected="true">Chart</button>
           </li>
           <li class="nav-item" role="presentation">
             <button class="nav-link" id="files-numbers-tab" data-toggle="tab" data-target="#files-numbers" type="button" role="tab" aria-controls="files-numbers" aria-selected="false">Numbers</button>
           </li>
           <li class="nav-item" role="presentation">
-            <button class="nav-link" id="files-trends-tab" data-toggle="tab" data-target="#files-trends" type="button" role="tab" aria-controls="files-trends" aria-selected="false">Trends</button>
+            <button class="nav-link active" id="files-trends-tab" data-toggle="tab" data-target="#files-trends" type="button" role="tab" aria-controls="files-trends" aria-selected="false">Trends</button>
           </li>
         </ul>
         <div class="card-body">
           <div class="tab-content" id="myTabContent">
-            <div class="tab-pane fade show active" id="files-chart" role="tabpanel" aria-labelledby="files-chart-tab">
+            <div class="tab-pane fade" id="files-chart" role="tabpanel" aria-labelledby="files-chart-tab">
               <canvas id="filesChart"></canvas>
             </div>
             <div class="tab-pane fade" id="files-numbers" role="tabpanel" aria-labelledby="files-numbers-tab">
               <p>Progress by files</p>
               <table class="table table-sm"><tbody></tbody></table>
             </div>
-            <div class="tab-pane fade" id="files-trends" role="tabpanel" aria-labelledby="files-trends-tab">
-              Insert line graph
+            <div class="tab-pane fade show active" id="files-trends" role="tabpanel" aria-labelledby="files-trends-tab">
               <canvas id="filesTrends"></canvas>
+              <a href="#" data-toggle="modal" data-target="#filesModal">Click to enlarge<span class="sr-only">progress by files line graph</span></a>
             </div>
           </div>
         </div>
@@ -83,27 +82,27 @@
       <div class="card h-100">
         <ul class="nav nav-tabs" id="objectsTabs" role="tablist">
           <li class="nav-item" role="presentation">
-            <button class="nav-link active" id="objects-chart-tab" data-toggle="tab" data-target="#objects-chart" type="button" role="tab" aria-controls="objects-chart" aria-selected="true">Chart</button>
+            <button class="nav-link" id="objects-chart-tab" data-toggle="tab" data-target="#objects-chart" type="button" role="tab" aria-controls="objects-chart" aria-selected="true">Chart</button>
           </li>
           <li class="nav-item" role="presentation">
             <button class="nav-link" id="objects-numbers-tab" data-toggle="tab" data-target="#objects-numbers" type="button" role="tab" aria-controls="objects-numbers" aria-selected="false">Numbers</button>
           </li>
           <li class="nav-item" role="presentation">
-            <button class="nav-link" id="objects-trends-tab" data-toggle="tab" data-target="#objects-trends" type="button" role="tab" aria-controls="objects-trends" aria-selected="false">Trends</button>
+            <button class="nav-link active" id="objects-trends-tab" data-toggle="tab" data-target="#objects-trends" type="button" role="tab" aria-controls="objects-trends" aria-selected="false">Trends</button>
           </li>
         </ul>
         <div class="card-body">
           <div class="tab-content" id="myTabContent">
-            <div class="tab-pane fade show active" id="objects-chart" role="tabpanel" aria-labelledby="objects-chart-tab">
+            <div class="tab-pane fade" id="objects-chart" role="tabpanel" aria-labelledby="objects-chart-tab">
               <canvas id="objectsChart"></canvas>
             </div>
             <div class="tab-pane fade" id="objects-numbers" role="tabpanel" aria-labelledby="objects-numbers-tab">
               <p>Progress by objects</p>
               <table class="table table-sm"><tbody></tbody></table>
             </div>
-            <div class="tab-pane fade" id="objects-trends" role="tabpanel" aria-labelledby="objects-trends-tab">
-              Insert line graph
+            <div class="tab-pane fade show active" id="objects-trends" role="tabpanel" aria-labelledby="objects-trends-tab">
               <canvas id="objectsTrends"></canvas>
+              <a href="#" data-toggle="modal" data-target="#objectsModal">Click to enlarge<span class="sr-only">progress by objects line graph</span></a>
             </div>
           </div>
         </div>
@@ -170,6 +169,66 @@
         </div>
         <div class="modal-body">
           <img class="hl__image " alt="diagram of migration statuses" src="{{ url_for('static', filename='images/status-diagram.png') }}"/>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal: progress by bytes line graph -->
+  <div class="modal fade" id="bytesModal" tabindex="-1" role="dialog" aria-labelledby="bytesModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title sr-only" id="bytesModalLabel">Progress by bytes</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <canvas id="bytesTrendsModal"></canvas>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal: progress by files line graph -->
+  <div class="modal fade" id="filesModal" tabindex="-1" role="dialog" aria-labelledby="filesModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title sr-only" id="filesModalLabel">Progress by files</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <canvas id="filesTrendsModal"></canvas>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal: progress by objects line graph -->
+  <div class="modal fade" id="objectsModal" tabindex="-1" role="dialog" aria-labelledby="objectsModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title sr-only" id="objectsModalLabel">Progress by files</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <canvas id="objectsTrendsModal"></canvas>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">Close</button>

--- a/app/templates/piechart.html
+++ b/app/templates/piechart.html
@@ -8,7 +8,7 @@
     <div class="col">
       <!-- <h1>DRS Migration Dashboard</h1> -->
       <p class="hl__time-stamp">Last update: <span class="hl__date">07/13/2021</span>, <span class="hl__time">1:03 PM</span></p>
-      <p>Statistics are updated hourly. For an explanation of each status, check the <a href="#" data-toggle="modal" data-target="#definitions">status definitions</a>. Also, refer to the <a href="#" data-toggle="modal" data-target="#diagram">status diagram</a> for a visual representation of the migration workflow.</p>
+      <p>Statistics are updated daily. For an explanation of each status, check the <a href="#" data-toggle="modal" data-target="#definitions">status definitions</a>. Also, refer to the <a href="#" data-toggle="modal" data-target="#diagram">status diagram</a> for a visual representation of the migration workflow.</p>
     </div>
   </div>
 


### PR DESCRIPTION
**Line graph + style changes**
* * *

**GitHub Issue**: (https://github.com/harvard-lts/drs-migration-dashboard/issues/7) 

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Introduces line graphs as a way to track progress and incorporated design feedback based on meeting with Janet

# How should this be tested?
Test page: https://localhost:3001/migrationstatus/piechart/

Line graphs
* Click on the "trends" tab in each card to see line graphs (used js to create arrays of the dates + totals remaining, then charts.js to create the line)
* Also did a little math to change the y-axis to TB/MB/KB accordingly, otherwise the y-axis was showing alllll the zeros and taking up far too much space in the card
* When cards are 3-across, the graphs are quite small and illegible, so added a "click to enlarge" link that opens up the line graph in a larger modal window (a suggestion from Janet)

Design updates
* Removed large title to push the dashboard content up higher on the page (header now says "DRS Migration Dashboard" and acts as the h1 for the page)
* Revised language and restyled the "last update" line to make more prominent
* Changed page's max container width so that cards could be larger (also set a min-width for the cards so that the graphs and doughnut charts can't get too small; cards now wrap nicely on the page)
* Updated colors for doughnut graphs (success is now a bright green, verified is teal, all others are the same as before)
* Updated tables in the numbers view (slightly smaller font-size, used Trueno light font for readability, numbers right-aligned)
* Updated definitions modal window to use Trueno font and added more padding between definitions

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no
- integration tests? no

# Interested parties
@dl-maura @phil-plencner-hl @awoods 