### PR TITLE
New objects tab + styling updates

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -693,20 +693,27 @@ th {
 td:last-child {
   text-align: right;
 }
+#objects-failed td {
+  text-align: left;
+}
 
 .card-body a {
-  font-size: 15px;
+  font-size: 12px;
   font-weight: normal;
   line-height: 24px;
 }
 
-
-.hl__prediction p {
-  font-size: 15px;
-  font-weight: 300;
-  margin-bottom: 0;
-  text-align: left;
+#bytesRegression {
+  margin-top: 40px;
 }
-.hl__prediction p span {
-	white-space: nowrap;
+.hl__prediction {
+  padding-top: 20px;
+}
+.hl__prediction table {
+	font-family: 'Trueno', Arial, Helvetica, sans-serif;
+  font-size: 14px;
+	font-weight: 300;
+}
+.hl__equation {
+  min-width: 190px;
 }

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -700,3 +700,14 @@ td:last-child {
   font-weight: normal;
   line-height: 24px;
 }
+
+
+.hl__prediction p {
+  font-size: 15px;
+  font-weight: 300;
+  margin-bottom: 0;
+  text-align: left;
+}
+.hl__prediction p span {
+	white-space: nowrap;
+}

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -675,9 +675,8 @@ dd {
   width:100%;
   margin-bottom:1rem;
   color:#414141;
-  font-family: "Trueno", sans-serif;
+  font-family: monospace;
   font-size: 15px;
-  font-weight: 300;
 }
 .tab-pane p {
   font-family: 'Trueno', Arial, Helvetica, sans-serif;

--- a/app/static/js/piechart.js
+++ b/app/static/js/piechart.js
@@ -146,6 +146,7 @@ $(document).ready(function () {
         datasets: [
           {
             backgroundColor: colors.slice(0,7),
+            hoverBackgroundColor: colors.slice(0,7),
             borderWidth: 1,
             data: files_data.slice(0,7)
           }
@@ -186,6 +187,7 @@ $(document).ready(function () {
         datasets: [
           {
             backgroundColor: colors.slice(0,7),
+            hoverBackgroundColor: colors.slice(0,7),
             borderWidth: 1,
             data: objects_data.slice(0,7)
           }

--- a/app/static/js/piechart.js
+++ b/app/static/js/piechart.js
@@ -43,7 +43,7 @@ $(document).ready(function () {
         data[i]["gsx$_clrrx"]["$t"],  // on hold
         data[i]["gsx$_cyevm"]["$t"],  // success
         data[i]["gsx$_cztg3"]["$t"],  // verified
-        data[i]["gsx$_d180g"]["$t"]   // verfied failed
+        data[i]["gsx$_d180g"]["$t"]   // verified failed
       ];
 
       let bytes_total = data[i]["gsx$_d2mkx"]["$t"]; // total
@@ -58,7 +58,7 @@ $(document).ready(function () {
         data[i]["gsx$_dcgjs"]["$t"],  // on hold
         data[i]["gsx$_ddv49"]["$t"],  // success
         data[i]["gsx$_d415a"]["$t"],  // verified
-        data[i]["gsx$_d5fpr"]["$t"]   // verfied failed
+        data[i]["gsx$_d5fpr"]["$t"]   // verified failed
       ];
 
       let files_total = data[i]["gsx$_d6ua4"]["$t"]; // total
@@ -73,7 +73,7 @@ $(document).ready(function () {
         data[i]["gsx$_dgo93"]["$t"],    // on hold
         data[i]["gsx$_di2tg"]["$t"],    // success
         data[i]["gsx$_djhdx"]["$t"],    // verified
-        data[i]["gsx$_dw4je"]["$t"]     // verfied failed
+        data[i]["gsx$_dw4je"]["$t"]     // verified failed
       ];
 
       let objects_total = data[i]["gsx$_dxj3v"]["$t"]; // total
@@ -101,12 +101,12 @@ $(document).ready(function () {
         }
       };
       let bytesChartData = {
-        labels: labels,
+        labels: labels.slice(0,7),
         datasets: [
           {
-            backgroundColor: colors.slice(0,9),
+            backgroundColor: colors.slice(0,7),
             borderWidth: 1,
-            data: bytes_data,
+            data: bytes_data.slice(0,7),
           }
         ]
       };
@@ -141,12 +141,12 @@ $(document).ready(function () {
         }
       };
       let filesChartData = {
-        labels: labels,
+        labels: labels.slice(0,7),
         datasets: [
           {
-            backgroundColor: colors.slice(0,9),
+            backgroundColor: colors.slice(0,7),
             borderWidth: 1,
-            data: files_data
+            data: files_data.slice(0,7)
           }
         ]
       };
@@ -181,12 +181,12 @@ $(document).ready(function () {
         }
       };
       let objectsChartData = {
-        labels: labels,
+        labels: labels.slice(0,7),
         datasets: [
           {
-            backgroundColor: colors.slice(0,9),
+            backgroundColor: colors.slice(0,7),
             borderWidth: 1,
-            data: objects_data
+            data: objects_data.slice(0,7)
           }
         ]
       };
@@ -214,11 +214,11 @@ $(document).ready(function () {
       for(i=1;i<data.length;i++){
         dateArray.push(data[i]["gsx$date"]["$t"]); // array of dates for x-axis
 
-        calcRemaining(bytesRemaining, data[i]["gsx$_d2mkx"]["$t"], data[i]["gsx$_cyevm"]["$t"], data[i]["gsx$_cztg3"]["$t"], data[i]["gsx$_d180g"]["$t"], 12);
+        calcRemaining(bytesRemaining, data[i]["gsx$_d2mkx"]["$t"], data[i]["gsx$_cyevm"]["$t"], 12);
 
-        calcRemaining(filesRemaining, data[i]["gsx$_d6ua4"]["$t"], data[i]["gsx$_ddv49"]["$t"], data[i]["gsx$_d415a"]["$t"], data[i]["gsx$_d5fpr"]["$t"], 6);
+        calcRemaining(filesRemaining, data[i]["gsx$_d6ua4"]["$t"], data[i]["gsx$_ddv49"]["$t"], 6);
 
-        calcRemaining(objectsRemaining, data[i]["gsx$_dxj3v"]["$t"], data[i]["gsx$_di2tg"]["$t"], data[i]["gsx$_djhdx"]["$t"], data[i]["gsx$_dw4je"]["$t"], 3);
+        calcRemaining(objectsRemaining, data[i]["gsx$_dxj3v"]["$t"], data[i]["gsx$_di2tg"]["$t"], 3);
       }
 
       // bytes trends
@@ -399,6 +399,81 @@ $(document).ready(function () {
       makePrediction(bytesRemaining, ".bytes-average", ".bytes-current", ".bytes-predict", 12);
       makePrediction(filesRemaining, ".files-average", ".files-current", ".files-predict", 6);
       makePrediction(objectsRemaining, ".objects-average", ".objects-current", ".objects-predict", 3);
+
+      // bytes regression
+      let bytesScatterArray = [];
+      for(i=0;i<data.length-1;i++){
+        bytesScatterArray.push({x: i, y: bytesRemaining[i]});
+      }
+      console.log(bytesScatterArray);
+
+
+      let m = -3034750908369/(10**12);
+      let b = 456388707979711/(10**12);
+      let yval = m*i + b;
+      let bytesRegressionArray = [
+        {x: 0,y: b},
+        {x: data.length - 2,y: m*(data.length - 2) + b}
+      ];
+
+      $(".hl__slope").html(m.toFixed(2));
+      $(".hl__yintercept").html(b.toFixed(2));
+      $(".hl__projection").html((-b/m).toFixed(2));
+
+      let bytesRegressionOptions = {
+        plugins: {
+          tooltip: {
+            mode: 'index',
+            intersect: false
+          },
+          title: {
+            display: true,
+            text: "Progress by bytes",
+            padding:{
+              top:10,
+              bottom:10
+            }
+          }
+        },
+        scales: {
+          x: {
+            title: {
+              display: true,
+              text: 'Days since started collecting data'
+            }
+          },
+          y: {
+            title: {
+              display: true,
+              text: 'TB remaining'
+            }
+          }
+        }
+      };
+      let bytesRegressionData = {
+        datasets: [{
+            label: 'Total TB remaining',
+            data: bytesScatterArray,
+            borderColor: colors[2],
+            backgroundColor: colors[2],
+            tension: 0.1
+        },{
+            label: 'Linear regression line',
+            data: bytesRegressionArray,
+            borderColor: colors[2],
+            backgroundColor: colors[2],
+            tension: 0.1,
+            type: 'line'
+        }]
+      };
+      let bytesRegression = document.getElementById("bytesRegression");
+      if (bytesRegression) {
+        new Chart(bytesRegression, {
+          type: 'scatter',
+          data: bytesRegressionData,
+          options: bytesRegressionOptions
+        });
+      }
     }
   };
 
@@ -430,8 +505,8 @@ $(document).ready(function () {
   }
 
   // create array of total amount remaining
-  function calcRemaining(array, total, success, verified, verified_failed, exponent){
-    let remaining = parseInt(total) - (parseInt(success) + parseInt(verified) + parseInt(verified_failed));
+  function calcRemaining(array, total, success, exponent){
+    let remaining = parseInt(total) - parseInt(success);
     array.push(remaining/(10**exponent));
   }
 

--- a/app/static/js/piechart.js
+++ b/app/static/js/piechart.js
@@ -14,7 +14,7 @@ $(document).ready(function () {
   Chart.defaults.plugins.title.font.lineHeight = 1.5;
 
   // chart colors
-  let colors = ['#c0c0c0','#f8c21c','#a51c30','#eb001b','#414141','#0579b8','#8BDA4C','#3E6F7D','red'];
+  let colors = ['#c0c0c0','#f8c21c','#a51c30','#eb001b','#414141','#0579b8','#8DBA4B','#3E6F7D','red'];
   let lineColor = '#3e6f7d';
 
   // labels
@@ -394,6 +394,11 @@ $(document).ready(function () {
           options: objectsTrendsOptions
         });
       }
+
+      // prediction data
+      makePrediction(bytesRemaining, ".bytes-average", ".bytes-current", ".bytes-predict", 12);
+      makePrediction(filesRemaining, ".files-average", ".files-current", ".files-predict", 6);
+      makePrediction(objectsRemaining, ".objects-average", ".objects-current", ".objects-predict", 3);
     }
   };
 
@@ -428,5 +433,17 @@ $(document).ready(function () {
   function calcRemaining(array, total, success, verified, verified_failed, exponent){
     let remaining = parseInt(total) - (parseInt(success) + parseInt(verified) + parseInt(verified_failed));
     array.push(remaining/(10**exponent));
+  }
+
+  // prediction calculations
+  function makePrediction(array, averageClass, currentClass, predictClass, exponent){
+    let total =  array[0] - array[array.length - 1];
+    let averageMigrated = Math.floor(total/(array.length)*(10**exponent));
+    let totalRemaining = (array[array.length - 1])*(10**exponent);
+    let prediction = Math.floor(totalRemaining / averageMigrated);
+
+    $(averageClass).html(" " + numberWithCommas(averageMigrated) + " bytes");
+    $(currentClass).html(" " + numberWithCommas(totalRemaining) + " bytes");
+    $(predictClass).html(" " + prediction + " days");
   }
 });

--- a/app/static/js/piechart.js
+++ b/app/static/js/piechart.js
@@ -105,6 +105,7 @@ $(document).ready(function () {
         datasets: [
           {
             backgroundColor: colors.slice(0,7),
+            hoverBackgroundColor: colors.slice(0,7),
             borderWidth: 1,
             data: bytes_data.slice(0,7),
           }
@@ -403,76 +404,6 @@ $(document).ready(function () {
         $("#objects-failed table tbody").append(
           '<tr><td>'+objFailed[i]+'</td></tr>'
         );
-      }
-
-
-      // bytes regression
-      let bytesScatterArray = [];
-      for(i=0;i<data.length-1;i++){
-        bytesScatterArray.push({x: i, y: bytesRemaining[i]});
-      }
-
-      // calculate line regression line
-      let m = -3034750908369/(10**12);
-      let b = 456388707979711/(10**12);
-      let yval = m*i + b;
-      let bytesRegressionArray = [
-        {x: 0,y: b},
-        {x: data.length - 2,y: m*(data.length - 2) + b}
-      ];
-
-      $(".hl__equation").html("y = " + m.toFixed(2) + "x + " + b.toFixed(2))
-      $(".hl__projection").html((-b/m).toFixed(2) + " days");
-
-      let bytesRegressionOptions = {
-        plugins: {
-          title: {
-            display: true,
-            text: "Best fitting regression line",
-            padding:{
-              top:10,
-              bottom:10
-            }
-          }
-        },
-        scales: {
-          x: {
-            title: {
-              display: true,
-              text: 'Days since started collecting data'
-            }
-          },
-          y: {
-            title: {
-              display: true,
-              text: 'TB remaining'
-            }
-          }
-        }
-      };
-      let bytesRegressionData = {
-        datasets: [{
-            label: 'Scatter plot',
-            data: bytesScatterArray,
-            borderColor: colors[2],
-            backgroundColor: colors[2],
-            type: 'scatter'
-        },{
-            label: 'Linear regression line',
-            data: bytesRegressionArray,
-            borderColor: colors[0],
-            backgroundColor: colors[0],
-            tension: 0.1,
-            type: 'line'
-        }]
-      };
-      let bytesRegression = document.getElementById("bytesRegression");
-      if (bytesRegression) {
-        new Chart(bytesRegression, {
-          type: 'scatter',
-          data: bytesRegressionData,
-          options: bytesRegressionOptions
-        });
       }
     }
   };

--- a/app/static/js/piechart.js
+++ b/app/static/js/piechart.js
@@ -199,6 +199,7 @@ $(document).ready(function () {
         });
       }
 
+
       // table views
       createTable("#bytes-numbers", bytes_data, bytes_total, bytes_percent_complete);
       createTable("#files-numbers", files_data, files_total, files_percent_complete);
@@ -395,19 +396,23 @@ $(document).ready(function () {
         });
       }
 
-      // prediction data
-      makePrediction(bytesRemaining, ".bytes-average", ".bytes-current", ".bytes-predict", 12);
-      makePrediction(filesRemaining, ".files-average", ".files-current", ".files-predict", 6);
-      makePrediction(objectsRemaining, ".objects-average", ".objects-current", ".objects-predict", 3);
+
+      // list of object ids for verified_failed
+      let objFailed = [482556371, 482559255, 482554466, 482559263, 482559259, 482556387, 482559267]
+      for(i=0;i<objFailed.length;i++){
+        $("#objects-failed table tbody").append(
+          '<tr><td>'+objFailed[i]+'</td></tr>'
+        );
+      }
+
 
       // bytes regression
       let bytesScatterArray = [];
       for(i=0;i<data.length-1;i++){
         bytesScatterArray.push({x: i, y: bytesRemaining[i]});
       }
-      console.log(bytesScatterArray);
 
-
+      // calculate line regression line
       let m = -3034750908369/(10**12);
       let b = 456388707979711/(10**12);
       let yval = m*i + b;
@@ -416,19 +421,14 @@ $(document).ready(function () {
         {x: data.length - 2,y: m*(data.length - 2) + b}
       ];
 
-      $(".hl__slope").html(m.toFixed(2));
-      $(".hl__yintercept").html(b.toFixed(2));
-      $(".hl__projection").html((-b/m).toFixed(2));
+      $(".hl__equation").html("y = " + m.toFixed(2) + "x + " + b.toFixed(2))
+      $(".hl__projection").html((-b/m).toFixed(2) + " days");
 
       let bytesRegressionOptions = {
         plugins: {
-          tooltip: {
-            mode: 'index',
-            intersect: false
-          },
           title: {
             display: true,
-            text: "Progress by bytes",
+            text: "Best fitting regression line",
             padding:{
               top:10,
               bottom:10
@@ -452,16 +452,16 @@ $(document).ready(function () {
       };
       let bytesRegressionData = {
         datasets: [{
-            label: 'Total TB remaining',
+            label: 'Scatter plot',
             data: bytesScatterArray,
             borderColor: colors[2],
             backgroundColor: colors[2],
-            tension: 0.1
+            type: 'scatter'
         },{
             label: 'Linear regression line',
             data: bytesRegressionArray,
-            borderColor: colors[2],
-            backgroundColor: colors[2],
+            borderColor: colors[0],
+            backgroundColor: colors[0],
             tension: 0.1,
             type: 'line'
         }]
@@ -491,11 +491,11 @@ $(document).ready(function () {
     let dataTable = $el.find("tbody");
     for(i=0;i<labels.length;i++){
       $(dataTable).append(
-        '<tr><td>'+labels[i]+'</td><td>'+numberWithCommas(data[i])+'</dt></tr>'
+        '<tr><td>'+labels[i]+'</td><td>'+numberWithCommas(data[i])+'</td></tr>'
       );
     }
     $(dataTable).append(
-      '<tr><td>Total</td><td>'+numberWithCommas(dataTotal)+'</dt></tr><tr><td>% complete</td><td>'+dataComplete+'</dt></tr>'
+      '<tr><td>Total</td><td>'+numberWithCommas(dataTotal)+'</td></tr><tr><td>% complete</td><td>'+dataComplete+'</td></tr>'
     );
   }
 
@@ -508,17 +508,5 @@ $(document).ready(function () {
   function calcRemaining(array, total, success, exponent){
     let remaining = parseInt(total) - parseInt(success);
     array.push(remaining/(10**exponent));
-  }
-
-  // prediction calculations
-  function makePrediction(array, averageClass, currentClass, predictClass, exponent){
-    let total =  array[0] - array[array.length - 1];
-    let averageMigrated = Math.floor(total/(array.length)*(10**exponent));
-    let totalRemaining = (array[array.length - 1])*(10**exponent);
-    let prediction = Math.floor(totalRemaining / averageMigrated);
-
-    $(averageClass).html(" " + numberWithCommas(averageMigrated) + " bytes");
-    $(currentClass).html(" " + numberWithCommas(totalRemaining) + " bytes");
-    $(predictClass).html(" " + prediction + " days");
   }
 });

--- a/app/templates/piechart.html
+++ b/app/templates/piechart.html
@@ -90,7 +90,7 @@
             <button class="nav-link" id="objects-trends-tab" data-toggle="tab" data-target="#objects-trends" type="button" role="tab" aria-controls="objects-trends" aria-selected="false">Trends</button>
           </li>
           <li class="nav-item" role="presentation">
-            <button class="nav-link" id="objects-failed-tab" data-toggle="tab" data-target="#objects-failed" type="button" role="tab" aria-controls="objects-failed" aria-selected="false">Failed IDs</button>
+            <button class="nav-link" id="objects-failed-tab" data-toggle="tab" data-target="#objects-failed" type="button" role="tab" aria-controls="objects-failed" aria-selected="false">Verified failed IDs</button>
           </li>
         </ul>
         <div class="card-body">

--- a/app/templates/piechart.html
+++ b/app/templates/piechart.html
@@ -18,31 +18,36 @@
       <div class="card h-100">
         <ul class="nav nav-tabs" id="bytesTabs" role="tablist">
           <li class="nav-item" role="presentation">
-            <button class="nav-link active" id="bytes-chart-tab" data-toggle="tab" data-target="#bytes-chart" type="button" role="tab" aria-controls="bytes-chart" aria-selected="true">Chart</button>
+            <button class="nav-link" id="bytes-chart-tab" data-toggle="tab" data-target="#bytes-chart" type="button" role="tab" aria-controls="bytes-chart" aria-selected="true">Chart</button>
           </li>
           <li class="nav-item" role="presentation">
             <button class="nav-link" id="bytes-numbers-tab" data-toggle="tab" data-target="#bytes-numbers" type="button" role="tab" aria-controls="bytes-numbers" aria-selected="false">Numbers</button>
           </li>
           <li class="nav-item" role="presentation">
-            <button class="nav-link" id="bytes-trends-tab" data-toggle="tab" data-target="#bytes-trends" type="button" role="tab" aria-controls="bytes-trends" aria-selected="false">Trends</button>
+            <button class="nav-link active" id="bytes-trends-tab" data-toggle="tab" data-target="#bytes-trends" type="button" role="tab" aria-controls="bytes-trends" aria-selected="false">Trends</button>
           </li>
         </ul>
         <div class="card-body">
           <div class="tab-content" id="myTabContent">
-            <div class="tab-pane fade show active" id="bytes-chart" role="tabpanel" aria-labelledby="bytes-chart-tab">
+            <div class="tab-pane fade" id="bytes-chart" role="tabpanel" aria-labelledby="bytes-chart-tab">
               <canvas id="bytesChart"></canvas>
             </div>
             <div class="tab-pane fade" id="bytes-numbers" role="tabpanel" aria-labelledby="bytes-numbers-tab">
               <p>Progress by bytes</p>
               <table class="table table-sm"><tbody></tbody></table>
             </div>
-            <div class="tab-pane fade" id="bytes-trends" role="tabpanel" aria-labelledby="bytes-trends-tab">
+            <div class="tab-pane fade show active" id="bytes-trends" role="tabpanel" aria-labelledby="bytes-trends-tab">
               <canvas id="bytesTrends"></canvas>
               <a href="#" data-toggle="modal" data-target="#bytesModal">Click to enlarge<span class="sr-only">progress by bytes line graph</span></a>
               <div class="hl__prediction">
                 <p>Average bytes migrated per day: <span class="bytes-average">#</span></p>
                 <p>Total bytes remaining today:<span class="bytes-current">#</span></p>
                 <p>Predicted # of days to completion: <span class="bytes-predict">#</span><p>
+              </div>
+              <canvas id="bytesRegression"></canvas>
+              <div class="hl__regression">
+                <p>Linear regression line equation:<br>y = <span class="hl__slope">m</span>x + <span class="hl__yintercept">b</span></p>
+                <p>Projected completion of migration in <span class="hl__projection">#</span> days.
               </div>
             </div>
           </div>
@@ -76,11 +81,6 @@
             <div class="tab-pane fade" id="files-trends" role="tabpanel" aria-labelledby="files-trends-tab">
               <canvas id="filesTrends"></canvas>
               <a href="#" data-toggle="modal" data-target="#filesModal">Click to enlarge<span class="sr-only">progress by files line graph</span></a>
-              <div class="hl__prediction">
-                <p>Average bytes migrated per day: <span class="files-average">#</span></p>
-                <p>Total bytes remaining today:<span class="files-current">#</span></p>
-                <p>Predicted # of days to completion: <span class="files-predict">#</span><p>
-              </div>
             </div>
           </div>
         </div>
@@ -113,11 +113,6 @@
             <div class="tab-pane fade" id="objects-trends" role="tabpanel" aria-labelledby="objects-trends-tab">
               <canvas id="objectsTrends"></canvas>
               <a href="#" data-toggle="modal" data-target="#objectsModal">Click to enlarge<span class="sr-only">progress by objects line graph</span></a>
-              <div class="hl__prediction">
-                <p>Average bytes migrated per day: <span class="objects-average">#</span></p>
-                <p>Total bytes remaining today:<span class="objects-current">#</span></p>
-                <p>Predicted # of days to completion: <span class="objects-predict">#</span><p>
-              </div>
             </div>
           </div>
         </div>

--- a/app/templates/piechart.html
+++ b/app/templates/piechart.html
@@ -90,7 +90,7 @@
             <button class="nav-link" id="objects-trends-tab" data-toggle="tab" data-target="#objects-trends" type="button" role="tab" aria-controls="objects-trends" aria-selected="false">Trends</button>
           </li>
           <li class="nav-item" role="presentation">
-            <button class="nav-link" id="objects-failed-tab" data-toggle="tab" data-target="#objects-failed" type="button" role="tab" aria-controls="objects-failed" aria-selected="false">Verify failed</button>
+            <button class="nav-link" id="objects-failed-tab" data-toggle="tab" data-target="#objects-failed" type="button" role="tab" aria-controls="objects-failed" aria-selected="false">Verify_failed</button>
           </li>
         </ul>
         <div class="card-body">
@@ -107,7 +107,7 @@
               <a href="#" data-toggle="modal" data-target="#objectsModal">Click to enlarge<span class="sr-only">progress by objects line graph</span></a>
             </div>
             <div class="tab-pane fade" id="objects-failed" role="tabpanel" aria-labelledby="objects-failed-tab">
-              <p>Verified failed object IDs</p>
+              <p>Verify_failed object IDs</p>
               <table class="table table-sm"><tbody></tbody></table>
             </div>
           </div>

--- a/app/templates/piechart.html
+++ b/app/templates/piechart.html
@@ -90,7 +90,7 @@
             <button class="nav-link" id="objects-trends-tab" data-toggle="tab" data-target="#objects-trends" type="button" role="tab" aria-controls="objects-trends" aria-selected="false">Trends</button>
           </li>
           <li class="nav-item" role="presentation">
-            <button class="nav-link" id="objects-failed-tab" data-toggle="tab" data-target="#objects-failed" type="button" role="tab" aria-controls="objects-failed" aria-selected="false">Verified failed IDs</button>
+            <button class="nav-link" id="objects-failed-tab" data-toggle="tab" data-target="#objects-failed" type="button" role="tab" aria-controls="objects-failed" aria-selected="false">Verify failed</button>
           </li>
         </ul>
         <div class="card-body">

--- a/app/templates/piechart.html
+++ b/app/templates/piechart.html
@@ -6,7 +6,6 @@
 <div class="container">
   <div class="row my-3">
     <div class="col">
-      <!-- <h1>DRS Migration Dashboard</h1> -->
       <p class="hl__time-stamp">Last update: <span class="hl__date">07/13/2021</span>, <span class="hl__time">1:03 PM</span></p>
       <p>Statistics are updated daily. For an explanation of each status, check the <a href="#" data-toggle="modal" data-target="#definitions">status definitions</a>. Also, refer to the <a href="#" data-toggle="modal" data-target="#diagram">status diagram</a> for a visual representation of the migration workflow.</p>
     </div>
@@ -39,15 +38,20 @@
             <div class="tab-pane fade show active" id="bytes-trends" role="tabpanel" aria-labelledby="bytes-trends-tab">
               <canvas id="bytesTrends"></canvas>
               <a href="#" data-toggle="modal" data-target="#bytesModal">Click to enlarge<span class="sr-only">progress by bytes line graph</span></a>
-              <div class="hl__prediction">
-                <p>Average bytes migrated per day: <span class="bytes-average">#</span></p>
-                <p>Total bytes remaining today:<span class="bytes-current">#</span></p>
-                <p>Predicted # of days to completion: <span class="bytes-predict">#</span><p>
-              </div>
               <canvas id="bytesRegression"></canvas>
-              <div class="hl__regression">
-                <p>Linear regression line equation:<br>y = <span class="hl__slope">m</span>x + <span class="hl__yintercept">b</span></p>
-                <p>Projected completion of migration in <span class="hl__projection">#</span> days.
+              <div class="hl__prediction">
+                <table class="table table-sm">
+                  <tbody>
+                    <tr>
+                      <td>Regression equation</td>
+                      <td class="hl__equation">>y = mx + b</td>
+                    </tr>
+                    <tr>
+                      <td>Projected completion</td>
+                      <td class="hl__projection">># days</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
@@ -92,7 +96,7 @@
       <div class="card h-100">
         <ul class="nav nav-tabs" id="objectsTabs" role="tablist">
           <li class="nav-item" role="presentation">
-            <button class="nav-link active" id="objects-chart-tab" data-toggle="tab" data-target="#objects-chart" type="button" role="tab" aria-controls="objects-chart" aria-selected="true">Chart</button>
+            <button class="nav-link" id="objects-chart-tab" data-toggle="tab" data-target="#objects-chart" type="button" role="tab" aria-controls="objects-chart" aria-selected="true">Chart</button>
           </li>
           <li class="nav-item" role="presentation">
             <button class="nav-link" id="objects-numbers-tab" data-toggle="tab" data-target="#objects-numbers" type="button" role="tab" aria-controls="objects-numbers" aria-selected="false">Numbers</button>
@@ -100,10 +104,13 @@
           <li class="nav-item" role="presentation">
             <button class="nav-link" id="objects-trends-tab" data-toggle="tab" data-target="#objects-trends" type="button" role="tab" aria-controls="objects-trends" aria-selected="false">Trends</button>
           </li>
+          <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="objects-failed-tab" data-toggle="tab" data-target="#objects-failed" type="button" role="tab" aria-controls="objects-failed" aria-selected="false">Failed IDs</button>
+          </li>
         </ul>
         <div class="card-body">
           <div class="tab-content" id="myTabContent">
-            <div class="tab-pane fade show active" id="objects-chart" role="tabpanel" aria-labelledby="objects-chart-tab">
+            <div class="tab-pane fade" id="objects-chart" role="tabpanel" aria-labelledby="objects-chart-tab">
               <canvas id="objectsChart"></canvas>
             </div>
             <div class="tab-pane fade" id="objects-numbers" role="tabpanel" aria-labelledby="objects-numbers-tab">
@@ -114,11 +121,17 @@
               <canvas id="objectsTrends"></canvas>
               <a href="#" data-toggle="modal" data-target="#objectsModal">Click to enlarge<span class="sr-only">progress by objects line graph</span></a>
             </div>
+            <div class="tab-pane fade show active" id="objects-failed" role="tabpanel" aria-labelledby="objects-failed-tab">
+              <p>Verified failed object IDs</p>
+              <table class="table table-sm"><tbody></tbody></table>
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
+
+  <canvas id="bytesRegressionModal"></canvas>
 
   <!-- Modal: status definitions -->
   <div class="modal fade" id="definitions" tabindex="-1" role="dialog" aria-labelledby="definitionsLabel" aria-hidden="true">

--- a/app/templates/piechart.html
+++ b/app/templates/piechart.html
@@ -17,42 +17,27 @@
       <div class="card h-100">
         <ul class="nav nav-tabs" id="bytesTabs" role="tablist">
           <li class="nav-item" role="presentation">
-            <button class="nav-link" id="bytes-chart-tab" data-toggle="tab" data-target="#bytes-chart" type="button" role="tab" aria-controls="bytes-chart" aria-selected="true">Chart</button>
+            <button class="nav-link active" id="bytes-chart-tab" data-toggle="tab" data-target="#bytes-chart" type="button" role="tab" aria-controls="bytes-chart" aria-selected="true">Chart</button>
           </li>
           <li class="nav-item" role="presentation">
             <button class="nav-link" id="bytes-numbers-tab" data-toggle="tab" data-target="#bytes-numbers" type="button" role="tab" aria-controls="bytes-numbers" aria-selected="false">Numbers</button>
           </li>
           <li class="nav-item" role="presentation">
-            <button class="nav-link active" id="bytes-trends-tab" data-toggle="tab" data-target="#bytes-trends" type="button" role="tab" aria-controls="bytes-trends" aria-selected="false">Trends</button>
+            <button class="nav-link" id="bytes-trends-tab" data-toggle="tab" data-target="#bytes-trends" type="button" role="tab" aria-controls="bytes-trends" aria-selected="false">Trends</button>
           </li>
         </ul>
         <div class="card-body">
           <div class="tab-content" id="myTabContent">
-            <div class="tab-pane fade" id="bytes-chart" role="tabpanel" aria-labelledby="bytes-chart-tab">
+            <div class="tab-pane fade show active" id="bytes-chart" role="tabpanel" aria-labelledby="bytes-chart-tab">
               <canvas id="bytesChart"></canvas>
             </div>
             <div class="tab-pane fade" id="bytes-numbers" role="tabpanel" aria-labelledby="bytes-numbers-tab">
               <p>Progress by bytes</p>
               <table class="table table-sm"><tbody></tbody></table>
             </div>
-            <div class="tab-pane fade show active" id="bytes-trends" role="tabpanel" aria-labelledby="bytes-trends-tab">
+            <div class="tab-pane fade" id="bytes-trends" role="tabpanel" aria-labelledby="bytes-trends-tab">
               <canvas id="bytesTrends"></canvas>
               <a href="#" data-toggle="modal" data-target="#bytesModal">Click to enlarge<span class="sr-only">progress by bytes line graph</span></a>
-              <canvas id="bytesRegression"></canvas>
-              <div class="hl__prediction">
-                <table class="table table-sm">
-                  <tbody>
-                    <tr>
-                      <td>Regression equation</td>
-                      <td class="hl__equation">>y = mx + b</td>
-                    </tr>
-                    <tr>
-                      <td>Projected completion</td>
-                      <td class="hl__projection">># days</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
             </div>
           </div>
         </div>
@@ -96,7 +81,7 @@
       <div class="card h-100">
         <ul class="nav nav-tabs" id="objectsTabs" role="tablist">
           <li class="nav-item" role="presentation">
-            <button class="nav-link" id="objects-chart-tab" data-toggle="tab" data-target="#objects-chart" type="button" role="tab" aria-controls="objects-chart" aria-selected="true">Chart</button>
+            <button class="nav-link active" id="objects-chart-tab" data-toggle="tab" data-target="#objects-chart" type="button" role="tab" aria-controls="objects-chart" aria-selected="true">Chart</button>
           </li>
           <li class="nav-item" role="presentation">
             <button class="nav-link" id="objects-numbers-tab" data-toggle="tab" data-target="#objects-numbers" type="button" role="tab" aria-controls="objects-numbers" aria-selected="false">Numbers</button>
@@ -105,12 +90,12 @@
             <button class="nav-link" id="objects-trends-tab" data-toggle="tab" data-target="#objects-trends" type="button" role="tab" aria-controls="objects-trends" aria-selected="false">Trends</button>
           </li>
           <li class="nav-item" role="presentation">
-            <button class="nav-link active" id="objects-failed-tab" data-toggle="tab" data-target="#objects-failed" type="button" role="tab" aria-controls="objects-failed" aria-selected="false">Failed IDs</button>
+            <button class="nav-link" id="objects-failed-tab" data-toggle="tab" data-target="#objects-failed" type="button" role="tab" aria-controls="objects-failed" aria-selected="false">Failed IDs</button>
           </li>
         </ul>
         <div class="card-body">
           <div class="tab-content" id="myTabContent">
-            <div class="tab-pane fade" id="objects-chart" role="tabpanel" aria-labelledby="objects-chart-tab">
+            <div class="tab-pane fade show active" id="objects-chart" role="tabpanel" aria-labelledby="objects-chart-tab">
               <canvas id="objectsChart"></canvas>
             </div>
             <div class="tab-pane fade" id="objects-numbers" role="tabpanel" aria-labelledby="objects-numbers-tab">
@@ -121,7 +106,7 @@
               <canvas id="objectsTrends"></canvas>
               <a href="#" data-toggle="modal" data-target="#objectsModal">Click to enlarge<span class="sr-only">progress by objects line graph</span></a>
             </div>
-            <div class="tab-pane fade show active" id="objects-failed" role="tabpanel" aria-labelledby="objects-failed-tab">
+            <div class="tab-pane fade" id="objects-failed" role="tabpanel" aria-labelledby="objects-failed-tab">
               <p>Verified failed object IDs</p>
               <table class="table table-sm"><tbody></tbody></table>
             </div>
@@ -130,8 +115,6 @@
       </div>
     </div>
   </div>
-
-  <canvas id="bytesRegressionModal"></canvas>
 
   <!-- Modal: status definitions -->
   <div class="modal fade" id="definitions" tabindex="-1" role="dialog" aria-labelledby="definitionsLabel" aria-hidden="true">

--- a/app/templates/piechart.html
+++ b/app/templates/piechart.html
@@ -39,6 +39,11 @@
             <div class="tab-pane fade" id="bytes-trends" role="tabpanel" aria-labelledby="bytes-trends-tab">
               <canvas id="bytesTrends"></canvas>
               <a href="#" data-toggle="modal" data-target="#bytesModal">Click to enlarge<span class="sr-only">progress by bytes line graph</span></a>
+              <div class="hl__prediction">
+                <p>Average bytes migrated per day: <span class="bytes-average">#</span></p>
+                <p>Total bytes remaining today:<span class="bytes-current">#</span></p>
+                <p>Predicted # of days to completion: <span class="bytes-predict">#</span><p>
+              </div>
             </div>
           </div>
         </div>
@@ -71,6 +76,11 @@
             <div class="tab-pane fade" id="files-trends" role="tabpanel" aria-labelledby="files-trends-tab">
               <canvas id="filesTrends"></canvas>
               <a href="#" data-toggle="modal" data-target="#filesModal">Click to enlarge<span class="sr-only">progress by files line graph</span></a>
+              <div class="hl__prediction">
+                <p>Average bytes migrated per day: <span class="files-average">#</span></p>
+                <p>Total bytes remaining today:<span class="files-current">#</span></p>
+                <p>Predicted # of days to completion: <span class="files-predict">#</span><p>
+              </div>
             </div>
           </div>
         </div>
@@ -103,6 +113,11 @@
             <div class="tab-pane fade" id="objects-trends" role="tabpanel" aria-labelledby="objects-trends-tab">
               <canvas id="objectsTrends"></canvas>
               <a href="#" data-toggle="modal" data-target="#objectsModal">Click to enlarge<span class="sr-only">progress by objects line graph</span></a>
+              <div class="hl__prediction">
+                <p>Average bytes migrated per day: <span class="objects-average">#</span></p>
+                <p>Total bytes remaining today:<span class="objects-current">#</span></p>
+                <p>Predicted # of days to completion: <span class="objects-predict">#</span><p>
+              </div>
             </div>
           </div>
         </div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ version: '3.8'
 services:
 
   drs-migration-dashboard:
-    image: registry.lts.harvard.edu/lts/drs-migration-dashboard:0.0.3
+    image: registry.lts.harvard.edu/lts/drs-migration-dashboard:0.0.4
     build:
       context: .
       dockerfile: DockerfilePub


### PR DESCRIPTION
**New objects tab + styling updates**
* * *

**GitHub Issues**: (https://github.com/harvard-lts/drs-migration-dashboard/issues/9)

# What does this Pull Request do?
Incorporates design feedback and a new tab tracking the id's of verified_failed objects (https://github.com/harvard-lts/drs-migration-dashboard/issues/9))

# How should this be tested?
https://localhost:3001/migrationstatus/piechart/
* Doughnut chart has an updated green color for "success"
* Doughnut "slices" no longer have a slight color change on hover
* Removed "verified" and "verified failed" from chart view after learning that these are included in the "success" metric
* Numbers table now using monospace font
* New "Verified failed IDs" tab for the object category (note: currently using a static array of object id's)
* Changed image to 0.0.4 in `docker-compose.yml` for when we're ready to push up to dev site

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no
- integration tests? no

# Interested parties
@dl-maura @awoods