### PR TITLE
Adding new healthcheck URL.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,7 @@ import os, click
 from flask import Flask, current_app
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from werkzeug.wrappers import Response
+from healthcheck import HealthCheck
 
 # Import custom modules from the local project
 # Import API resources
@@ -26,5 +27,9 @@ def create_app():
 
   # Resources
   resources.define_resources(app)
+
+  # Health Check
+  health = HealthCheck()
+  app.add_url_rule("/healthcheck", "healthcheck", view_func=health.run)
 
   return app

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ jmespath==0.10.0
 jsonschema==3.2.0
 MarkupSafe==1.1.1
 py==1.10.0
+py-healthcheck==1.10.1
 PyJWT==1.7.1
 pyrsistent==0.17.3
 python-dateutil==2.8.1


### PR DESCRIPTION
**Adding new healthcheck URL.**
* * *

**JIRA Ticket**: [14](https://github.com/harvard-lts/drs-migration-dashboard/issues/14)

# What does this Pull Request do?
When I removed the API stuff as part of the task to remove `/piechart/` URL, the Docker healthcheck was relying on the `/version/` endpoint.  This PR adds a new route for `/healthcheck/` that we can use in the Docker healthcheck.

# How should this be tested?

A description of what steps someone could take to:
* _**COMPLETELY REBUILD**_ your docker container (to install the [py-healthcheck](https://github.com/ateliedocodigo/py-healthcheck) library: `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
* Go to this URL and you should see a status of "success": https://localhost:3001/migrationstatus/healthcheck
* The main page of the site should still work as usual: https://localhost:3001/migrationstatus/
* The piechart redirect should still work as well: https://localhost:3001/migrationstatus/piechart/

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz @mferrarini 