### PR TITLE
Change failed_ids from render to file download.

### DIFF
--- a/app/data_files.py
+++ b/app/data_files.py
@@ -9,10 +9,3 @@ class DataFiles():
             migration_data = json.load(migration_file)
         current_app.logger.info('Successfully loaded migration data.')
         return json.dumps(migration_data)
-    def get_failed_list(self):
-        current_app.logger.info('Loading failed list from json file.')
-        filename = os.path.join(current_app.static_folder, 'files', 'failed_file.json')
-        with open(filename) as failed_file:
-            failed_list = json.load(failed_file)
-        current_app.logger.info('Successfully loaded failed list.')
-        return json.dumps(failed_list)

--- a/app/resources.py
+++ b/app/resources.py
@@ -1,5 +1,5 @@
 from flask_restx import Resource
-from flask import request, current_app, make_response, jsonify, render_template, redirect, url_for
+from flask import request, current_app, make_response, jsonify, render_template, redirect, send_from_directory, url_for
 import os, json
 
 # Import data files
@@ -10,8 +10,12 @@ def define_resources(app):
     def status():
         data_service = data_files.DataFiles()
         migration_data = data_service.get_migration_data()
-        failed_list = data_service.get_failed_list()
-        return render_template('status.html', migration_data = migration_data, failed_list = failed_list )
+        return render_template('status.html', migration_data = migration_data)
+    @app.route('/download-failed-files/')
+    def download_failed_files():
+        folder = os.path.join(current_app.static_folder, 'files')
+        file = 'failed_file.json'
+        return send_from_directory(folder, file, as_attachment=True) 
     @app.route('/piechart/')
     def piechart():
         return redirect(url_for('status'), code=301)

--- a/app/static/js/status.js
+++ b/app/static/js/status.js
@@ -396,14 +396,6 @@ $(document).ready(function () {
   }
 
 
-  // list of object ids for verify_failed
-  let objFailed = JSON.parse(failed_list);
-  for(i=0;i<objFailed.length;i++){
-    $("#objects-failed table tbody").append(
-      '<tr><td>'+objFailed[i]['FailedItems']+'</td></tr>'
-    );
-  }
-
   // bytes regression
   let bytesScatterArray = []; // x and y values to plot
   let lr = {}; // object for regression stats

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -2,7 +2,6 @@
 {% block chart_js %}
 <script>
   let migration_data = {{ migration_data|tojson }};
-  let failed_list = {{ failed_list|tojson }};
 </script>
 <script src="{{ url_for('static', filename='js/status.js') }}"></script>
 {% endblock %}
@@ -117,7 +116,7 @@
             </div>
             <div class="tab-pane fade" id="objects-failed" role="tabpanel" aria-labelledby="objects-failed-tab">
               <p>Verify_failed object IDs</p>
-              <table class="table table-sm"><tbody></tbody></table>
+              <p><a href="/migrationstatus/download-failed-files/">Download list of verify_failed object IDs</a></p>
             </div>
           </div>
         </div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ version: '3.8'
 services:
 
   drs-migration-dashboard:
-    image: registry.lts.harvard.edu/lts/drs-migration-dashboard:0.0.8
+    image: registry.lts.harvard.edu/lts/drs-migration-dashboard:0.0.9
     build:
       context: .
       dockerfile: DockerfilePub


### PR DESCRIPTION
**Change failed_ids from render to file download.**
* * *

**JIRA Ticket**: None

# What does this Pull Request do?
When the list of failed_ids gets too large (today it was over 100,000 ids) it takes too long to render in a browser. This PR no longer includes the failed_files in a json blob in the html and does not attempt to render them on the page. The `verify_failed` tab instead has a link to download the .json file to your local computer.

# How should this be tested?

A description of what steps someone could take to:
* Ensure that you have a file on your local computer at this location: `/app/static/files/failed_files.json` Put one there (doesn't need to be a valid json file) if you do not have one. 
* Completely rebuild the container `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
* Click on the `verified_failed` tab of the `Progress By Objects` chart
* Click on the link for `Download list of verify_failed object IDs`
* The JSON file should download to your computer.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz @awoods 