### PR TITLE
Change % migrated label to be more accurate

### DIFF
--- a/app/static/js/status.js
+++ b/app/static/js/status.js
@@ -568,7 +568,7 @@ $(document).ready(function () {
 
     // Total calculations
     $(dataTable).append(
-      '<tr><th colspan="2">Totals</th></tr><tr><td>Total</td><td>'+numberWithCommas(dataTotal)+'</td></tr><tr><td>% migrated</td><td>'+dataMigrated+'%</td></tr>'+'</td></tr><tr><td>% verified</td><td>'+dataComplete+'%</td></tr>'
+      '<tr><th colspan="2">Totals</th></tr><tr><td>Total</td><td>'+numberWithCommas(dataTotal)+'</td></tr><tr><td>% awaiting verification</td><td>'+dataMigrated+'%</td></tr>'+'</td></tr><tr><td>% verified</td><td>'+dataComplete+'%</td></tr>'
     );
 
     // Unrecoverable


### PR DESCRIPTION
**Change % migrated label to be more accurate**
* * *

# What does this Pull Request do?
Relabels '% migrated' to '% awaiting verification' which is more correct as everything verified has also been migrated.

# How should this be tested?

Make sure you have a copy of drs_migration.json to work with in app/static/files (doesn't matter if it is the most recent since the accuracy of the numbers is not relevant to this pr). Rebuild your container and go to https://localhost:3001/migrationstatus/. On the numbers tabs you will see the new label under the Totals section (note: I had to clear my cache so if you see the old label you may need to do that)

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? N
- integration tests? N

# Interested parties
@awoods @mferrarini 